### PR TITLE
feat: enhance editor with landing page and zoom

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,6 +5,7 @@ import { ThemeProvider } from "@/components/ui/theme-provider";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { BrowserRouter, Routes, Route } from "react-router-dom";
 import Index from "./pages/Index";
+import Editor from "./pages/Editor";
 import NotFound from "./pages/NotFound";
 
 const queryClient = new QueryClient();
@@ -18,6 +19,7 @@ const App = () => (
         <BrowserRouter>
           <Routes>
             <Route path="/" element={<Index />} />
+            <Route path="/editor" element={<Editor />} />
             {/* ADD ALL CUSTOM ROUTES ABOVE THE CATCH-ALL "*" ROUTE */}
             <Route path="*" element={<NotFound />} />
           </Routes>

--- a/src/pages/Editor.tsx
+++ b/src/pages/Editor.tsx
@@ -1,0 +1,7 @@
+import { MermaidDiagramMaker } from '@/components/MermaidDiagramMaker';
+
+const Editor = () => {
+  return <MermaidDiagramMaker />;
+};
+
+export default Editor;

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -1,7 +1,20 @@
-import { MermaidDiagramMaker } from '@/components/MermaidDiagramMaker';
+import { Link } from 'react-router-dom';
+import { Button } from '@/components/ui/button';
 
 const Index = () => {
-  return <MermaidDiagramMaker />;
+  return (
+    <div className="min-h-screen flex flex-col items-center justify-center text-center px-4 bg-gradient-to-br from-background via-background to-muted/20">
+      <h1 className="text-5xl md:text-6xl font-extrabold mb-6 bg-gradient-to-r from-primary to-primary/60 bg-clip-text text-transparent">
+        Mermaid Diagram Maker
+      </h1>
+      <p className="text-lg text-muted-foreground max-w-2xl mb-8">
+        Create beautiful diagrams in seconds with our intuitive editor and AI assistance.
+      </p>
+      <Button asChild size="lg">
+        <Link to="/editor">Get Started</Link>
+      </Button>
+    </div>
+  );
 };
 
 export default Index;


### PR DESCRIPTION
## Summary
- add themed landing page with hero and start button
- upgrade diagram editor with AI streaming, zoom controls, and first-time tooltips
- fix dark mode text rendering

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ac35ee0e38832ba08a137045cca94c